### PR TITLE
修正关于LB56x QFN系列的描述错误 | fix LB56x QFN series description mistakes

### DIFF
--- a/source/silicon/芯片型号指南.md
+++ b/source/silicon/芯片型号指南.md
@@ -88,7 +88,7 @@ Temperature  | -40~85C     | -40~85C     | -40~85C     | -40~85C     | -40~85C  
 - SF32LB56x系列支持以下显示接口
     - DPI/RGB888，RGB565 （566VCB36和567VND36）
     - SPI/DSPI/QSPI，包括墨水屏SPI接口
-    - 8080-8bit
+    - 8080-8bit（QFN68L未完全引出）
 
 Part #            | 560UNN26    | 561UBN26    | 563UCN26    | 56WUND26    | 566VCB36          | 567VND36
 :-|-:|-:|-:|-:|-:|-:
@@ -100,7 +100,7 @@ LCPU GPIOs        | 20          | 20          | 20          | 20          | 41  
 MPI5 Boot SiP     | 512KB NOR   | 512KB NOR   | 512KB NOR   | 512KB NOR   | 1MB NOR           | 1MB NOR 
 MPI1 SiP          | n/a         | 4MB OPI-P   | 8MB OPI-P   | n/a         | 8MB OPI-P         | n/a 
 MPI2 SiP          | n/a         | n/a         | n/a         | 16MB OPI-P  | 4MB OPI-P         | 16MB OPI-P 
-Display Interface | QSPI/8080   | QSPI/8080   | QSPI/8080   | QSPI/8080   | DPI/QSPI/8080/JDI | DPI/QSPI/8080/JDI 
+Display Interface | QSPI        | QSPI        | QSPI        | QSPI        | DPI/QSPI/8080/JDI | DPI/QSPI/8080/JDI 
 Power Supply      | 1.71~3.63V  | 1.71~3.63V  | 1.71~3.63V  | 1.71~3.63V  | 1.71~3.63V        | 1.71~3.63V
 Temperature       | -40~85C     | -40~85C     | -40~85C     | -40~85C     | -40~85C           | -40~85C 
 

--- a/source/silicon/芯片型号指南.md
+++ b/source/silicon/芯片型号指南.md
@@ -88,7 +88,7 @@ Temperature  | -40~85C     | -40~85C     | -40~85C     | -40~85C     | -40~85C  
 - SF32LB56x系列支持以下显示接口
     - DPI/RGB888，RGB565 （566VCB36和567VND36）
     - SPI/DSPI/QSPI，包括墨水屏SPI接口
-    - 8080-8bit（QFN68L未完全引出）
+    - 8080-8bit（仅限566VCB36和567VND36QFN68L；在QFN型号上未完全引出）
 
 Part #            | 560UNN26    | 561UBN26    | 563UCN26    | 56WUND26    | 566VCB36          | 567VND36
 :-|-:|-:|-:|-:|-:|-:


### PR DESCRIPTION
尽管 LB56x 支持 8080-8bit 的LCD接口，但 QFN68 封装的型号中并未引出全部所需要的信号。根据最新的数据手册内容来看，QFN68L封装的芯片只引出了 D0、D1、D2、D5、TE、CS、WR、RD、DC 信号，因此事实上 8080-8bit 接口没法用。
Although LB56x has support of 8080-8bit LCD interface, not all necessary pins are available on QFN68 models. According to the latest DS only D0，D1，D2，D5，TE，CS，WR，RD，DC signals are available, 8080-8bit interface cannot be used on QFN68L models in fact.