### PR TITLE
fix 52拉距测试文档网页无法显示

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+    "MicroPython.executeButton": [
+        {
+            "text": "▶",
+            "tooltip": "运行",
+            "alignment": "left",
+            "command": "extension.executeFile",
+            "priority": 3.5
+        }
+    ],
+    "MicroPython.syncButton": [
+        {
+            "text": "$(sync)",
+            "tooltip": "同步",
+            "alignment": "left",
+            "command": "extension.execute",
+            "priority": 4
+        }
+    ]
+}

--- a/source/zh_CN/appnote/index.md
+++ b/source/zh_CN/appnote/index.md
@@ -11,4 +11,5 @@
 应用程序启动流程 <https://docs.sifli.com/projects/sdk/latest/sf32lb52x/app_development/startup_flow.html>
 NandFlash_BBM解析指南 <pm/NandFlash_BBM解析指南>
 SF32LB52-DevKit-Core-3p3开发板测试指南 <pm/SF32LB52-DevKit-Core-3p3开发板测试指南>
+思澈52平台拉距测试 <pm/思澈52平台拉距测试>
 ``` 

--- a/source/zh_CN/appnote/pm/思澈52平台拉距测试.md
+++ b/source/zh_CN/appnote/pm/思澈52平台拉距测试.md
@@ -12,8 +12,6 @@
 
 固件获取：[ble_range_test_sf32lb52-core_n4_v5.2](https://downloads.sifli.com/52ble_range_test_latest/400m_sf32lb52-core_n4_v5.2.zip)
 
-
-
 ## 三、固件烧录
 
 ### 1. 烧录工具（Impeller）
@@ -112,7 +110,7 @@ Core板支持两种天线选择，板载陶瓷天线和外接天线。
 
 |	拉高的引脚           	   |   发射功率（dBm）  |
 |:-----------------------|:-----------|
-| PA26    | 10     
+| PA26    | 10   
 | PA25    | 13
 | PA24    | 16
 
@@ -142,7 +140,6 @@ Core板支持两种天线选择，板载陶瓷天线和外接天线。
 ### 3.LED状态（PA32）
 
 可以根据LED状态板子的模式以及板子连接状态。
-
 
 ```{table}
 :name:  LED 状态
@@ -184,8 +181,6 @@ BLE 协议栈初始化后会打印:
 
 该行确认功率已经下发到 BLE 控制器
 
-
-
 ## 五、测试及参考数据
 
 ```{important}
@@ -213,29 +208,27 @@ BLE 协议栈初始化后会打印:
 :name: 拉距测试环境1
 
 | 环境1 | 19dBm | 16dBm | 13dBm | 10dBm |
-|:----- |:-----|:------|:-------|:--- --|
+|:------|:------|:------|:------|:------|
 | 第一次测试 | 606m | 576m | 210m | 186m |
-| 第二次测试 | 561m | 563m | 530m | 496m |  
+| 第二次测试 | 561m | 563m | 530m | 496m |
 | 第三次测试 | 576m | 518m | 392m | 452m |
 
 ```
 
 测试环境2：
 
- <img src="assets/image_2.png" width="25%" high="25%" align="center" />
+<img src="assets/image_2.png" width="25%" high="25%" align="center" />
 
- 
 ```{table}
 :name: 拉距测试环境2
 
 | 环境1 | 19dBm | 16dBm | 13dBm | 10dBm |
-|:----- |:-----|:------|:-------|:--- --|
+|:------|:------|:------|:------|:------|
 | 第一次测试 | 452m | 417m | 409m | 363m |
-| 第二次测试 | 449m | 417m | 460m | 375m |  
+| 第二次测试 | 449m | 417m | 460m | 375m |
 | 第三次测试 | 460m | 447m | 392m | 422m |
 
 ```
 
 [Impeller]: https://downloads.sifli.com/tools/Impeller/Impeller_latest.7z
 [Impeller使用说明]: https://wiki.sifli.com/tools/%E7%83%A7%E5%BD%95%E5%B7%A5%E5%85%B7.html
-


### PR DESCRIPTION
This pull request introduces a new application note for BLE range testing on the 思澈52 platform, updates documentation references, and makes minor formatting and configuration improvements.

**Documentation additions and updates:**

* Added a new application note file `思澈52平台拉距测试.md`, which provides instructions and reference data for BLE range testing on the 思澈52 platform. [[1]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L15-L16) [[2]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L216-R211) [[3]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L227-R226)
* Updated the `index.md` to include a reference to the new BLE range testing application note.

**Formatting and table corrections:**

* Fixed table formatting in the BLE range testing document to ensure proper display of test data. [[1]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L216-R211) [[2]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L227-R226)
* Removed extraneous blank lines and improved section separation in the BLE range testing document. [[1]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L15-L16) [[2]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L146) [[3]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L187-L188) [[4]](diffhunk://#diff-d09579cc70798ef08ca5e32432dd38869fdd86fc9c0aab460f48ceb3f9205e59L241)

**Development environment configuration:**

* Added VSCode settings to provide custom MicroPython execute and sync buttons in the editor. (.vscode/settings.json)